### PR TITLE
Fix shimmer keyframes location

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -18,11 +18,11 @@ const config: Config = {
           600: '#2F6FEB',
         },
       },
-    },
-    keyframes: {
-      shimmer: {
-        '100%': {
-          transform: 'translateX(100%)',
+      keyframes: {
+        shimmer: {
+          '100%': {
+            transform: 'translateX(100%)',
+          },
         },
       },
     },


### PR DESCRIPTION
## Summary
- fix location of shimmer keyframes in tailwind config

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845115cc10c832cbe9f1f1355d57de5